### PR TITLE
Unpack jars with DLLs

### DIFF
--- a/bundles/svnapi.javahl.win32/META-INF/MANIFEST.MF
+++ b/bundles/svnapi.javahl.win32/META-INF/MANIFEST.MF
@@ -6,3 +6,4 @@ Bundle-Version: 1.14.0.qualifier
 Bundle-Vendor: Subclipse
 Fragment-Host: org.tigris.subversion.clientadapter.javahl;bundle-version="1.14.0.1"
 Eclipse-PlatformFilter: (& (osgi.os=win32) (osgi.arch=x86))
+Eclipse-BundleShape: dir

--- a/bundles/svnapi.javahl.win64/META-INF/MANIFEST.MF
+++ b/bundles/svnapi.javahl.win64/META-INF/MANIFEST.MF
@@ -6,3 +6,4 @@ Bundle-Version: 1.14.0.qualifier
 Bundle-Vendor: Subclipse
 Fragment-Host: org.tigris.subversion.clientadapter.javahl;bundle-version="1.14.0.1"
 Eclipse-PlatformFilter: (& (osgi.os=win32) (osgi.arch=x86_64))
+Eclipse-BundleShape: dir

--- a/releng/javahl.configuration/pom.xml
+++ b/releng/javahl.configuration/pom.xml
@@ -9,7 +9,7 @@
   <tycho.version>0.25.0</tycho.version>
   <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   <juno-repo.url>http://download.eclipse.org/releases/juno</juno-repo.url>
-  <svn-repo.url>https://dl.bintray.com/subclipse/snapshots/subclipse/master</svn-repo.url>
+  <svn-repo.url>https://subclipse.github.io/snapshots</svn-repo.url>
  </properties>
 
  <repositories>


### PR DESCRIPTION
In Tycho-based product builds, the DLLs are not extracted as the `unpack="true"` from the feature.xml (commit 20fd2a65020bf4aeb4d3ac1233c8f111d8f5aa8c) is apparently not taken into consideration.
To ensure unpacking, each bundle's `MANIFEST.MF` has to specify `Eclipse-BundleShape: dir`.

I also changed the snapshot repo URL because the local build didn't work without this.
